### PR TITLE
Fix vimdoc quotes at start-of-file leaking into docs (#20)

### DIFF
--- a/vimdoc/parser.py
+++ b/vimdoc/parser.py
@@ -49,9 +49,12 @@ def EnumerateStripNewlinesAndJoinContinuations(lines):
 
 
 def EnumerateParsedLines(lines):
-  # The intro chunk doesn't need the double-quote introduction.
-  vimdoc_mode = True
+  vimdoc_mode = False
   for i, line in EnumerateStripNewlinesAndJoinContinuations(lines):
+    # The intro chunk doesn't need the double-quote introduction (but leave
+    # explicit vimdoc leaders alone to be detected and stripped below).
+    if i == 0 and IsComment(line) and not regex.vimdoc_leader.match(line):
+      vimdoc_mode = True
     if not vimdoc_mode:
       if regex.vimdoc_leader.match(line):
         vimdoc_mode = True


### PR DESCRIPTION
Makes explicit vimdoc leaders work properly at start-of-file so people can go ahead and start using them. Implicit vimdoc blocks will eventually be removed (#42), so it's nice to have some period of time between must-use-implicit behavior and must-use-explicit.
