### PR TITLE
Disable implicit vimdoc blocks at start-of-file.

### DIFF
--- a/vimdoc/parser.py
+++ b/vimdoc/parser.py
@@ -51,10 +51,6 @@ def EnumerateStripNewlinesAndJoinContinuations(lines):
 def EnumerateParsedLines(lines):
   vimdoc_mode = False
   for i, line in EnumerateStripNewlinesAndJoinContinuations(lines):
-    # The intro chunk doesn't need the double-quote introduction (but leave
-    # explicit vimdoc leaders alone to be detected and stripped below).
-    if i == 0 and IsComment(line) and not regex.vimdoc_leader.match(line):
-      vimdoc_mode = True
     if not vimdoc_mode:
       if regex.vimdoc_leader.match(line):
         vimdoc_mode = True


### PR DESCRIPTION
Disable the magic that treats the first comment block of any file as a potential vimdoc block, even if there's no explicit vimdoc leader. After this change, you must include an explicit vimdoc leader on every vimdoc block if you want vimdoc to use it.

This may cause users who forgot to add vimdoc leaders to have vimdoc comments mysteriously dropped or to see errors like
`NeglectedSections: Sections set(['usage', 'commands', 'intro', 'config']) not included in ordering` if blocks with global directives are dropped. I wanted to show warnings for newly-dropped blocks that would have previously been detected, but the code structure makes it difficult to warn in just the right instances.

Fixes #42.
