### PR TITLE
Document no-description commands/funcs and don't warn for them

### DIFF
--- a/vimdoc/output.py
+++ b/vimdoc/output.py
@@ -98,13 +98,6 @@ class Helpfile(object):
 
   def WriteLargeBlock(self, block):
     """Writes a large (function, command, etc.) type block."""
-    if not block.paragraphs:
-      warnings.warn(
-          'Undocumented {} {}'.format(
-              block.locals.get('type').lower(),
-              block.FullName()),
-          error.DocumentationWarning)
-      return
     assert 'usage' in block.locals
     self.WriteLine(
         # The leader='' makes it indent once on subsequent lines.


### PR DESCRIPTION
Fixes #64.

I could be convinced to add the warning back in, but if we want to have any chance of people reading our warnings I'm pretty sure we should save them for significant problems and not nag people with opinionated warnings.
