### PR TITLE
Fix NeglectedSections error to not claim every section is neglected

### DIFF
--- a/vimdoc/error.py
+++ b/vimdoc/error.py
@@ -117,6 +117,6 @@ class NoSuchSection(BadStructure):
 
 
 class NeglectedSections(BadStructure):
-  def __init__(self, sections):
+  def __init__(self, sections, order):
     super(NeglectedSections, self).__init__(
-        'Sections {} not included in ordering.'.format(sections))
+        'Sections {} not included in ordering {}.'.format(sections, order))

--- a/vimdoc/module.py
+++ b/vimdoc/module.py
@@ -1,6 +1,5 @@
 """Vimdoc plugin management."""
 from collections import OrderedDict
-import itertools
 import json
 import os
 import warnings
@@ -117,9 +116,10 @@ class Module(object):
     for backmatter in self.backmatters:
       if backmatter not in self.sections:
         raise error.NoSuchSection(backmatter)
-    known = set(itertools.chain(self.sections, self.backmatters))
-    if known.difference(self.order):
-      raise error.NeglectedSections(known)
+    known = set(self.sections) | set(self.backmatters)
+    neglected = sorted(known.difference(self.order))
+    if neglected:
+      raise error.NeglectedSections(neglected, self.order)
     # Sections are now in order.
     for key in self.order:
       if key in self.sections:


### PR DESCRIPTION
The NeglectedSections error (the one you see if you declare a `@section` without listing the id in `@order`), looked like `vimdoc.error.NeglectedSections: Sections set(['every', 'detected', 'section']) not included in ordering.`, but some of those sections are already in `@order` and not all are actually neglected.

This fixes the error to include the neglected section names as well as the complete `@order` list.
