### PR TITLE
Pass explicit encoding when opening files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Distribution for vimdoc."""
-import codecs
 from distutils.core import setup
+import io
 import os.path
 import sys
 
@@ -12,7 +12,7 @@ if sys.version_info[0] < 3:
 
 
 VERSION_PATH = os.path.join(os.path.dirname(__file__), 'vimdoc/VERSION.txt')
-with codecs.open(VERSION_PATH, 'r', 'utf-8') as f:
+with io.open(VERSION_PATH, 'r', encoding='utf-8') as f:
   version = f.read().strip()
 
 LONG_DESCRIPTION = """

--- a/vimdoc/module.py
+++ b/vimdoc/module.py
@@ -1,5 +1,6 @@
 """Vimdoc plugin management."""
 from collections import OrderedDict
+import io
 import json
 import os
 import warnings
@@ -377,7 +378,7 @@ def Modules(directory):
   addon_info_path = os.path.join(directory, 'addon-info.json')
   if os.path.isfile(addon_info_path):
     try:
-      with open(addon_info_path, 'r') as addon_info_file:
+      with io.open(addon_info_path, 'r', encoding='utf-8') as addon_info_file:
         addon_info = json.loads(addon_info_file.read())
     except (IOError, ValueError) as e:
       warnings.warn(
@@ -417,7 +418,7 @@ def Modules(directory):
       filename = os.path.join(root, f)
       if os.path.splitext(filename)[1] == '.vim':
         relative_path = os.path.relpath(filename, directory)
-        with open(filename) as filehandle:
+        with io.open(filename, encoding='utf-8') as filehandle:
           lines = list(filehandle)
           blocks = list(parser.ParseBlocks(lines, filename))
           # Define implicit maktaba flags for files that call

--- a/vimdoc/output.py
+++ b/vimdoc/output.py
@@ -1,4 +1,5 @@
 """Vim helpfile outputter."""
+import io
 import os
 import textwrap
 
@@ -24,7 +25,7 @@ class Helpfile(object):
 
   def Write(self):
     filename = os.path.join(self.docdir, self.Filename())
-    with open(filename, 'w') as self.file:
+    with io.open(filename, 'w', encoding='utf-8') as self.file:
       self.WriteHeader()
       self.WriteTableOfContents()
       for chunk in self.module.Chunks():


### PR DESCRIPTION
Fixes #104.

Uses `io.open` everywhere as recommended at https://stackoverflow.com/a/22288895 instead of `open` builtin or `codecs.open` (even though python 2 compatibility isn't essential here).