### PR TITLE
Fix autoload namespace detection issues on Windows using os.path.sep

### DIFF
--- a/vimdoc/module.py
+++ b/vimdoc/module.py
@@ -491,7 +491,7 @@ def Modules(directory):
 
 
 def GetAutoloadNamespace(filepath):
-  return (os.path.splitext(filepath)[0]).replace('/', '#') + '#'
+  return (os.path.splitext(filepath)[0]).replace(os.path.sep, '#') + '#'
 
 
 def GetMatchingStandalonePath(path, standalones):


### PR DESCRIPTION
Uses platform-independent os.path.sep instead of hard-coded / character when getting autoload namespace.

Fixes #106.