### PR TITLE
Avoid creating flag "plugin[flags]"

### DIFF
--- a/vimdoc/module.py
+++ b/vimdoc/module.py
@@ -426,6 +426,7 @@ def Modules(directory):
           # because there aren't necessarily associated doc comment blocks and
           # the name is computed from the file name.
           if (not relative_path.startswith('autoload' + os.path.sep)
+              and relative_path != os.path.join('plugin', 'flags.vim')
               and relative_path != os.path.join('instant', 'flags.vim')):
             if ContainsMaktabaPluginEnterCall(lines):
               flagpath = relative_path


### PR DESCRIPTION
Skips generating docs for a "plugin[flags]" flag corresponding to a detected plugin/flags.vim file. Just like with instant/flags.vim files, there doesn't need to be a flag to prevent loading a flags file.

This helps prepare for moving away from instant/flags.vim files (see google/vim-maktaba#189).