### PR TITLE
Add shell completions by shtab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,127 @@
-*.pyc
-/MANIFEST
-/build/
 /deb_dist/
-/dist/
+
+# Python.gitignore:
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     scripts=[
         'scripts/vimdoc',
     ],
+    extras_require={'completion': ['shtab']},
     package_data={'vimdoc': ['VERSION.txt']},
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/vimdoc/_shtab.py
+++ b/vimdoc/_shtab.py
@@ -1,0 +1,8 @@
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser, *args, **kwargs):
+    from argparse import Action
+    Action.complete = None  # type: ignore
+    return parser

--- a/vimdoc/args.py
+++ b/vimdoc/args.py
@@ -3,6 +3,11 @@ import os
 
 import vimdoc
 
+try:
+    import shtab
+except ImportError:
+    from . import _shtab as shtab
+
 
 def Source(path):
   if not os.path.isdir(path):
@@ -11,7 +16,9 @@ def Source(path):
     raise argparse.ArgumentTypeError('Cannot access {}'.format(path))
   return path
 
-parser = argparse.ArgumentParser(description='Generate vim helpfiles')
-parser.add_argument('plugin', type=Source, metavar='PLUGIN')
+
+parser = argparse.ArgumentParser('vimdoc', description='Generate vim helpfiles')
+shtab.add_argument_to(parser)
+parser.add_argument('plugin', type=Source, metavar='PLUGIN').complete = shtab.DIR
 parser.add_argument('--version', action='version',
     version='%(prog)s ' + vimdoc.__version__)


### PR DESCRIPTION
```sh
vimdoc --print-completion bash | sudo tee /usr/share/bash-completion/completions/vimdoc
vimdoc --print-completion tcsh | sudo tee /etc/profile.d/vimdoc.completion.csh
vimdoc --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_vimdoc
```

```sh
❯ vimdoc -<TAB>
option
--help               show this help message and exit
-h                   show this help message and exit
--print-completion   print shell completion script
--version            show program's version number and exit
❯ vimdoc <TAB>
plugin
scripts/  tests/    vimdoc/
```

```python
    extras_require={'completion': ['shtab']},
```
