### PR TITLE
Add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+---
+- id: vimdoc
+  name: vimdoc
+  description: "Helpfile generation for vim"
+  entry: vimdoc
+  language: python
+  pass_filenames: false
+  types:
+    - vim
+  args:
+    - .


### PR DESCRIPTION
According to <https://pre-commit.com/#new-hooks>, I write this hook and test it
can work for me:

`.pre-commit-config.yaml`

```yaml
  - repo: https://github.com/Freed-Wu/vimdoc
    rev: master
    hooks:
      - id: vimdoc
```

I advice to publish a new version because `rev: master` is fragile and pre-commit will warn due to it.

```sh
❯ git commit
[WARNING] The 'rev' field of repo 'https://github.com/Freed-Wu/vimdoc' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
[INFO] Initializing environment for https://github.com/Freed-Wu/vimdoc.
[INFO] Installing environment for https://github.com/Freed-Wu/vimdoc.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
...
Vint Vim script linting.......................................................Passed
vimdoc........................................................................Passed
```