### PR TITLE
Delete old cruft file stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,0 @@
-[DEFAULT]
-Package: vimdoc-BROKEN
-Package3: vimdoc
-Section: devel


### PR DESCRIPTION
The stdeb build instructions have been broken for years.