### PR TITLE
RFC: Basic implementation of vimdoc on top of vim-plugin-metadata lib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
 ]
 urls = {Repository = "https://github.com/google/vimdoc"}
 dynamic = ["version"]
+dependencies = [
+  "vim-plugin-metadata >= 1.0.0-rc.0",
+]
 
 [project.optional-dependencies]
 completion = ["shtab"]


### PR DESCRIPTION
Demonstrates how vimdoc could leverage https://pypi.org/project/vim-plugin-metadata to simplify away regex logic, make the parsing more robust (probably fixing lots of existing bugs), and lay groundwork for cleanly supporting more complex user requests in the future.

Note: I did a kinda strange partial conversion for this RFC to make the changes slightly easier to follow: even though all the vimscript processing is coming via the vim-plugin-metadata lib, it reconstructs parts of the metadata into pseudo-vimscript (in `vimdoc.parser.AffectForVimNode`) and feeds them back through some of vimdoc's preexisting regex processing. That's easy enough to clean up if this overall approach looks good and we do decide to finalize and merge it.