### PR TITLE
Attempt to address #119

### DIFF
--- a/vimdoc/block.py
+++ b/vimdoc/block.py
@@ -254,7 +254,10 @@ class Block(object):
         return '{}.{}'.format(self.locals['dict'], attribute)
       if 'exception' in self.locals:
         return 'ERROR({})'.format(self.locals['exception'] or self.LocalName())
-      return self.locals.get('namespace', '') + self.LocalName()
+      if self.locals.get('namespace', '') is None:
+        print("Warning: skipping None returned by -> `self.locals.get('namespace', '')` for ->", self.LocalName())
+      else:
+        return self.locals.get('namespace', '') + self.LocalName()
     return self.LocalName()
 
   def TagName(self):

--- a/vimdoc/module.py
+++ b/vimdoc/module.py
@@ -99,8 +99,11 @@ class Module(object):
       # Sort by namespace, but preserve order within the same namespace. This
       # lets us avoid variability in the order files are traversed without
       # losing all useful order information.
-      collection = sorted(collection,
-          key=lambda x: x.locals.get('namespace', ''))
+      try:
+        collection = sorted(collection,
+            key=lambda x: x.locals.get('namespace', ''))
+      except TypeError as e:
+        print('Module.GetCollection failed sorting collection ->', collection)
     elif typ == vimdoc.DICTIONARY:
       collection = sorted(collection)
     non_default_names = set(x.TagName() for x in collection


### PR DESCRIPTION
> Note: I'm not yet savvy enough with the source to sort-out why
> `self.locals.get` is returning `None` instead of an empty string.
>
> But this seems to work well enough for me :shrug: